### PR TITLE
all: Use CoreV1() instead of Core()

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -11,7 +11,7 @@ import (
 func (test *Test) createNamespace(name string) (*v1.Namespace, error) {
 	test.Infof("creating namespace %s", name)
 
-	namespace, err := test.harness.kubeClient.Core().Namespaces().Create(&v1.Namespace{
+	namespace, err := test.harness.kubeClient.CoreV1().Namespaces().Create(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -43,5 +43,5 @@ func (test *Test) deleteNamespace(name string) error {
 
 	test.removeNamespace(name)
 
-	return test.harness.kubeClient.Core().Namespaces().Delete(name, nil)
+	return test.harness.kubeClient.CoreV1().Namespaces().Delete(name, nil)
 }

--- a/node.go
+++ b/node.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (test *Test) listNodes(options metav1.ListOptions) (*v1.NodeList, error) {
-	return test.harness.kubeClient.Core().Nodes().List(options)
+	return test.harness.kubeClient.CoreV1().Nodes().List(options)
 }
 
 // ListNodes returns all nodes that are part of the cluster.

--- a/pod.go
+++ b/pod.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (test *Test) listPods(namespace string, options metav1.ListOptions) (*v1.PodList, error) {
-	return test.harness.kubeClient.Core().Pods(namespace).List(options)
+	return test.harness.kubeClient.CoreV1().Pods(namespace).List(options)
 }
 
 // ListPods returns the list of pods in namespace matching options.
@@ -64,7 +64,7 @@ func (test *Test) PodReady(pod v1.Pod) (bool, error) {
 // container to pass its readiness check.
 func (test *Test) WaitForPodsReady(namespace string, opts metav1.ListOptions, expectedReplicas int, timeout time.Duration) error {
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
-		pl, err := test.harness.kubeClient.Core().Pods(namespace).List(opts)
+		pl, err := test.harness.kubeClient.CoreV1().Pods(namespace).List(opts)
 		if err != nil {
 			return false, err
 		}
@@ -98,7 +98,7 @@ func (test *Test) PodLogs(w io.Writer, pod *v1.Pod, containerName string) error 
 		containerName = pod.Spec.Containers[0].Name
 	}
 
-	logs, err := test.harness.kubeClient.Core().RESTClient().Get().
+	logs, err := test.harness.kubeClient.CoreV1().RESTClient().Get().
 		Resource("pods").
 		Namespace(pod.Namespace).
 		Name(pod.Name).SubResource("log").


### PR DESCRIPTION
Core() has been removed in recent versions of client-go. Always use CoreV1()!