### PR TITLE
Fix Harness.ManifestDirectory typo in godoc comments

### DIFF
--- a/configmap.go
+++ b/configmap.go
@@ -41,7 +41,7 @@ func (test *Test) loadConfigMap(manifestPath string) (*v1.ConfigMap, error) {
 }
 
 // LoadConfigMap loads a ConfigMap from a YAML manifest. The path to the
-// manifest is relative to Harness.ManifestsDirectory.
+// manifest is relative to Harness.ManifestDirectory.
 func (test *Test) LoadConfigMap(manifestPath string) *v1.ConfigMap {
 	dep, err := test.loadConfigMap(manifestPath)
 	test.err(err)

--- a/daemonset.go
+++ b/daemonset.go
@@ -43,7 +43,7 @@ func (test *Test) loadDaemonSet(manifestPath string) (*appsv1.DaemonSet, error) 
 }
 
 // LoadDaemonSet loads a daemonset from a YAML manifest. The path to the
-// manifest is relative to Harness.ManifestsDirectory.
+// manifest is relative to Harness.ManifestDirectory.
 func (test *Test) LoadDaemonSet(manifestPath string) *appsv1.DaemonSet {
 	dep, err := test.loadDaemonSet(manifestPath)
 	test.err(err)

--- a/deployment.go
+++ b/deployment.go
@@ -43,7 +43,7 @@ func (test *Test) loadDeployment(manifestPath string) (*appsv1.Deployment, error
 }
 
 // LoadDeployment loads a deployment from a YAML manifest. The path to the
-// manifest is relative to Harness.ManifestsDirectory.
+// manifest is relative to Harness.ManifestDirectory.
 func (test *Test) LoadDeployment(manifestPath string) *appsv1.Deployment {
 	dep, err := test.loadDeployment(manifestPath)
 	test.err(err)

--- a/secret.go
+++ b/secret.go
@@ -41,7 +41,7 @@ func (test *Test) loadSecret(manifestPath string) (*v1.Secret, error) {
 }
 
 // LoadSecret loads a secret from a YAML manifest. The path to the
-// manifest is relative to Harness.ManifestsDirectory.
+// manifest is relative to Harness.ManifestDirectory.
 func (test *Test) LoadSecret(manifestPath string) *v1.Secret {
 	dep, err := test.loadSecret(manifestPath)
 	test.err(err)

--- a/service.go
+++ b/service.go
@@ -40,7 +40,7 @@ func (test *Test) loadService(manifestPath string) (*v1.Service, error) {
 }
 
 // LoadService loads a service from a YAML manifest. The path to the
-// manifest is relative to Harness.ManifestsDirectory.
+// manifest is relative to Harness.ManifestDirectory.
 func (test *Test) LoadService(manifestPath string) *v1.Service {
 	dep, err := test.loadService(manifestPath)
 	test.err(err)


### PR DESCRIPTION
The field is named ManifestDirectory, not ManifestsDirectory.