### PR TITLE
Use Go stdlib functions for error wrapping

### DIFF
--- a/configmap.go
+++ b/configmap.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -16,7 +14,7 @@ import (
 func (test *Test) createConfigMap(namespace string, cm *v1.ConfigMap) error {
 	cm.Namespace = namespace
 	if _, err := test.harness.kubeClient.CoreV1().ConfigMaps(namespace).Create(context.TODO(), cm, metav1.CreateOptions{}); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to create ConfigMap %v ", cm.Name))
+		return fmt.Errorf("failed to create ConfigMap %s: %w", cm.Name, err)
 	}
 	return nil
 }
@@ -34,7 +32,7 @@ func (test *Test) loadConfigMap(manifestPath string) (*v1.ConfigMap, error) {
 	}
 	dep := v1.ConfigMap{}
 	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&dep); err != nil {
-		return nil, errors.Wrapf(err, "failed to decode ConfigMap %s", manifestPath)
+		return nil, fmt.Errorf("failed to decode ConfigMap %s: %w", manifestPath, err)
 	}
 
 	return &dep, nil
@@ -69,7 +67,7 @@ func (test *Test) CreateConfigMapFromFile(namespace string, manifestPath string)
 
 func (test *Test) deleteConfigMap(ConfigMap *v1.ConfigMap) error {
 	if err := test.harness.kubeClient.CoreV1().ConfigMaps(ConfigMap.Namespace).Delete(context.TODO(), ConfigMap.Name, metav1.DeleteOptions{}); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("deleting ConfigMap %v failed", ConfigMap.Name))
+		return fmt.Errorf("deleting ConfigMap %s failed: %w", ConfigMap.Name, err)
 	}
 	return nil
 }

--- a/daemonset.go
+++ b/daemonset.go
@@ -2,9 +2,9 @@ package harness
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +18,7 @@ func (test *Test) createDaemonSet(namespace string, d *appsv1.DaemonSet) error {
 	d.Namespace = namespace
 	_, err := test.harness.kubeClient.AppsV1().DaemonSets(namespace).Create(context.TODO(), d, metav1.CreateOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "failed to create daemonset %s", d.Name)
+		return fmt.Errorf("failed to create daemonset %s: %w", d.Name, err)
 	}
 	return nil
 }
@@ -36,7 +36,7 @@ func (test *Test) loadDaemonSet(manifestPath string) (*appsv1.DaemonSet, error) 
 	}
 	dep := appsv1.DaemonSet{}
 	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&dep); err != nil {
-		return nil, errors.Wrapf(err, "failed to decode daemonset %s", manifestPath)
+		return nil, fmt.Errorf("failed to decode daemonset %s: %w", manifestPath, err)
 	}
 
 	return &dep, nil

--- a/deployment.go
+++ b/deployment.go
@@ -2,9 +2,9 @@ package harness
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +18,7 @@ func (test *Test) createDeployment(namespace string, d *appsv1.Deployment) error
 	d.Namespace = namespace
 	_, err := test.harness.kubeClient.AppsV1().Deployments(namespace).Create(context.TODO(), d, metav1.CreateOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "failed to create deployment %s", d.Name)
+		return fmt.Errorf("failed to create deployment %s: %w", d.Name, err)
 	}
 	return nil
 }
@@ -36,7 +36,7 @@ func (test *Test) loadDeployment(manifestPath string) (*appsv1.Deployment, error
 	}
 	dep := appsv1.Deployment{}
 	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&dep); err != nil {
-		return nil, errors.Wrapf(err, "failed to decode deployment %s", manifestPath)
+		return nil, fmt.Errorf("failed to decode deployment %s: %w", manifestPath, err)
 	}
 
 	return &dep, nil

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.14
 
 require (
 	github.com/imdario/mergo v0.3.9 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,6 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=

--- a/harness.go
+++ b/harness.go
@@ -1,13 +1,13 @@
 package harness
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/dlespiau/kube-test-harness/logger"
 	"github.com/dlespiau/kube-test-harness/testing"
 
-	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -76,7 +76,7 @@ func resolveDirectory(in string) (string, error) {
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", errors.Wrap(err, "harness")
+		return "", fmt.Errorf("failed to get working directory: %w", err)
 	}
 
 	if in == "" {
@@ -166,7 +166,7 @@ func (h *Harness) openManifest(manifest string) (*os.File, error) {
 	path := filepath.Join(h.options.ManifestDirectory, manifest)
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "open manifest")
+		return nil, fmt.Errorf("failed to open manifest: %w", err)
 	}
 
 	return f, nil

--- a/namespace.go
+++ b/namespace.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -18,7 +17,7 @@ func (test *Test) createNamespace(name string) (*v1.Namespace, error) {
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to create namespace with name %v", name))
+		return nil, fmt.Errorf("failed to create namespace with name %v: %w", name, err)
 	}
 	return namespace, nil
 }

--- a/secret.go
+++ b/secret.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -16,7 +14,7 @@ import (
 func (test *Test) createSecret(namespace string, secret *v1.Secret) error {
 	secret.Namespace = namespace
 	if _, err := test.harness.kubeClient.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to create secret %v ", secret.Name))
+		return fmt.Errorf("failed to create secret %s: %w", secret.Name, err)
 	}
 	return nil
 }
@@ -34,7 +32,7 @@ func (test *Test) loadSecret(manifestPath string) (*v1.Secret, error) {
 	}
 	dep := v1.Secret{}
 	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&dep); err != nil {
-		return nil, errors.Wrapf(err, "failed to decode secret %s", manifestPath)
+		return nil, fmt.Errorf("failed to decode secret %s: %w", manifestPath, err)
 	}
 
 	return &dep, nil
@@ -69,7 +67,7 @@ func (test *Test) CreateSecretFromFile(namespace string, manifestPath string) *v
 
 func (test *Test) deleteSecret(secret *v1.Secret) error {
 	if err := test.harness.kubeClient.CoreV1().Secrets(secret.Namespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{}); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("deleting secret %v failed", secret.Name))
+		return fmt.Errorf("deleting secret %s failed: %w", secret.Name, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Use `fmt.Errorf` with the `%w` verb (available since Go 1.13) instead of
`errors.Wrap` from the external `github.com/pkg/errors` to wrap error
values. See https://blog.golang.org/go1.13-errors for details.

Also consistently use the `%s` verb to format object names.