### PR TITLE
Add ClusterRole and ClusterRoleBinding helpers

### DIFF
--- a/clusterrole.go
+++ b/clusterrole.go
@@ -1,0 +1,102 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func (test *Test) createClusterRole(cr *rbacv1.ClusterRole) error {
+	if _, err := test.harness.kubeClient.RbacV1().ClusterRoles().Create(context.TODO(), cr, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create cluster role %s: %w", cr.Name, err)
+	}
+	return nil
+}
+
+// CreateClusterRole creates a cluster role.
+func (test *Test) CreateClusterRole(cr *rbacv1.ClusterRole) {
+	err := test.createClusterRole(cr)
+	test.err(err)
+}
+
+func (test *Test) loadClusterRole(manifestPath string) (*rbacv1.ClusterRole, error) {
+	manifest, err := test.harness.openManifest(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	dep := rbacv1.ClusterRole{}
+	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&dep); err != nil {
+		return nil, fmt.Errorf("failed to decode cluster role %s: %w", manifestPath, err)
+	}
+	return &dep, nil
+}
+
+// LoadClusterRole loads a cluster role from a YAML manifest. The path to the
+// manifest is relative to Harness.ManifestDirectory.
+func (test *Test) LoadClusterRole(manifestPath string) *rbacv1.ClusterRole {
+	cr, err := test.loadClusterRole(manifestPath)
+	test.err(err)
+	return cr
+}
+
+func (test *Test) createClusterRoleFromFile(manifestPath string) (*rbacv1.ClusterRole, error) {
+	cr, err := test.loadClusterRole(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	err = test.createClusterRole(cr)
+	if err != nil {
+		return nil, err
+	}
+	return cr, nil
+}
+
+// CreateClusterRoleFromFile creates a cluster role from a manifest file.
+func (test *Test) CreateClusterRoleFromFile(manifestPath string) *rbacv1.ClusterRole {
+	cr, err := test.createClusterRoleFromFile(manifestPath)
+	test.err(err)
+	return cr
+}
+
+func (test *Test) deleteClusterRole(cr *rbacv1.ClusterRole) error {
+	if err := test.harness.kubeClient.RbacV1().ClusterRoles().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("deleting cluster role %s failed: %w", cr.Name, err)
+	}
+	return nil
+}
+
+// DeleteClusterRole deletes a cluster role.
+func (test *Test) DeleteClusterRole(cr *rbacv1.ClusterRole) {
+	err := test.deleteClusterRole(cr)
+	test.err(err)
+}
+
+// GetClusterRole returns a ClusterRole object if it exists or error.
+func (test *Test) GetClusterRole(name string) (*rbacv1.ClusterRole, error) {
+	cr, err := test.harness.kubeClient.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return cr, nil
+}
+
+func (test *Test) waitForClusterRoleReady(name string, timeout time.Duration) error {
+	return wait.Poll(time.Second, timeout, func() (bool, error) {
+		_, err := test.GetClusterRole(name)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+// WaitForClusterRoleReady waits until ClusterRole is created, otherwise times out.
+func (test *Test) WaitForClusterRoleReady(cr *rbacv1.ClusterRole, timeout time.Duration) {
+	err := test.waitForClusterRoleReady(cr.Name, timeout)
+	test.err(err)
+}

--- a/clusterrolebinding.go
+++ b/clusterrolebinding.go
@@ -1,0 +1,102 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func (test *Test) createClusterRoleBinding(crb *rbacv1.ClusterRoleBinding) error {
+	if _, err := test.harness.kubeClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), crb, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create cluster role binding %s: %w", crb.Name, err)
+	}
+	return nil
+}
+
+// CreateClusterRoleBinding creates a cluster role binding.
+func (test *Test) CreateClusterRoleBinding(crb *rbacv1.ClusterRoleBinding) {
+	err := test.createClusterRoleBinding(crb)
+	test.err(err)
+}
+
+func (test *Test) loadClusterRoleBinding(manifestPath string) (*rbacv1.ClusterRoleBinding, error) {
+	manifest, err := test.harness.openManifest(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	dep := rbacv1.ClusterRoleBinding{}
+	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&dep); err != nil {
+		return nil, fmt.Errorf("failed to decode cluster role binding %s: %w", manifestPath, err)
+	}
+	return &dep, nil
+}
+
+// LoadClusterRoleBinding loads a cluster role binding from a YAML manifest. The path to the
+// manifest is relative to Harness.ManifestDirectory.
+func (test *Test) LoadClusterRoleBinding(manifestPath string) *rbacv1.ClusterRoleBinding {
+	crb, err := test.loadClusterRoleBinding(manifestPath)
+	test.err(err)
+	return crb
+}
+
+func (test *Test) createClusterRoleBindingFromFile(manifestPath string) (*rbacv1.ClusterRoleBinding, error) {
+	crb, err := test.loadClusterRoleBinding(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	err = test.createClusterRoleBinding(crb)
+	if err != nil {
+		return nil, err
+	}
+	return crb, nil
+}
+
+// CreateClusterRoleBindingFromFile creates a cluster role binding from a manifest file.
+func (test *Test) CreateClusterRoleBindingFromFile(manifestPath string) *rbacv1.ClusterRoleBinding {
+	crb, err := test.createClusterRoleBindingFromFile(manifestPath)
+	test.err(err)
+	return crb
+}
+
+func (test *Test) deleteClusterRoleBinding(crb *rbacv1.ClusterRoleBinding) error {
+	if err := test.harness.kubeClient.RbacV1().ClusterRoleBindings().Delete(context.TODO(), crb.Name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("deleting cluster role binding %s failed: %w", crb.Name, err)
+	}
+	return nil
+}
+
+// DeleteClusterRoleBinding deletes a cluster role binding.
+func (test *Test) DeleteClusterRoleBinding(crb *rbacv1.ClusterRoleBinding) {
+	err := test.deleteClusterRoleBinding(crb)
+	test.err(err)
+}
+
+// GetClusterRoleBinding returns a ClusterRoleBinding object if it exists or error.
+func (test *Test) GetClusterRoleBinding(name string) (*rbacv1.ClusterRoleBinding, error) {
+	crb, err := test.harness.kubeClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return crb, nil
+}
+
+func (test *Test) waitForClusterRoleBindingReady(name string, timeout time.Duration) error {
+	return wait.Poll(time.Second, timeout, func() (bool, error) {
+		_, err := test.GetClusterRoleBinding(name)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+// WaitForClusterRoleBindingReady waits until ClusterRoleBinding is created, otherwise times out.
+func (test *Test) WaitForClusterRoleBindingReady(crb *rbacv1.ClusterRole, timeout time.Duration) {
+	err := test.waitForClusterRoleBindingReady(crb.Name, timeout)
+	test.err(err)
+}


### PR DESCRIPTION
Another one :smile: This should allow to use all k8s objects needed for Cilium.

Thanks a lot for this project and for merging the previous PRs so quickly @dlespiau!