### PR TITLE
Add GetNamespace and DeleteNamespace helpers

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -45,3 +45,18 @@ func (test *Test) deleteNamespace(name string) error {
 
 	return test.harness.kubeClient.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
 }
+
+// DeleteNamespace deletes a Namespace.
+func (test *Test) DeleteNamespace(name string) {
+	err := test.deleteNamespace(name)
+	test.err(err)
+}
+
+// GetNamespace returns a Namespace object if it exists or error.
+func (test *Test) GetNamespace(name string) (*v1.Namespace, error) {
+	ns, err := test.harness.kubeClient.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return ns, nil
+}

--- a/test.go
+++ b/test.go
@@ -206,14 +206,11 @@ func (t *Test) addNamespace(ns string) {
 }
 
 func (t *Test) removeNamespace(ns string) {
-	new := make([]string, 0, len(t.namespaces)-1)
-	for _, s := range t.namespaces {
+	for i, s := range t.namespaces {
 		if s == ns {
-			continue
+			t.namespaces = append(t.namespaces[:i], t.namespaces[i+1:]...)
 		}
-		new = append(new, s)
 	}
-	t.namespaces = new
 }
 
 func (t *Test) addFinalizer(fn finalizer) {

--- a/test_test.go
+++ b/test_test.go
@@ -1,0 +1,33 @@
+package harness
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddRemoveNamespace(t *testing.T) {
+	test := &Test{}
+	assert.Equal(t, len(test.namespaces), 0)
+
+	test.removeNamespace("foobar")
+	assert.Equal(t, len(test.namespaces), 0)
+
+	test.addNamespace("ns1")
+	assert.Equal(t, len(test.namespaces), 1)
+	assert.Equal(t, test.namespaces[0], "ns1")
+
+	test.addNamespace("ns2")
+	assert.Equal(t, len(test.namespaces), 2)
+
+	test.removeNamespace("ns1")
+	assert.Equal(t, len(test.namespaces), 1)
+	assert.Equal(t, test.namespaces[0], "ns2")
+
+	test.removeNamespace("ns1")
+	assert.Equal(t, len(test.namespaces), 1)
+	assert.Equal(t, test.namespaces[0], "ns2")
+
+	test.removeNamespace("ns2")
+	assert.Equal(t, len(test.namespaces), 0)
+}


### PR DESCRIPTION
For some Cilium tests we would like to force the namespace used by
kube-test-harness, i.e.
    
```go
ciliumTestNamespace := "cilium-test"
test := h.NewTest(t)
test.Namespace = ciliumTestNamespace
test.Setup()
defer test.Close()
```
   
In order to be able to check whether `ciliumNamespace` already exists, we
need a `GetNamespace` helper and a `DeleteNamespace` helper in case it
already exists and needs to be deleted first:

```go
if ns, err := test.GetNamespace(ciliumNamespace); err == nil && ns != nil {
	t.Logf("namespace %s already exists, deleting it", ciliumNamespace)
	test.DeleteNamespace(ciliumNamespace)

	timeout := 10 * time.Second
	err := wait.Poll(time.Second, timeout, func() (bool, error) {
		_, err := test.GetNamespace(ciliumNamespace)
		if err != nil {
			return true, nil
		}
		return false, nil
	})
	if err != nil {
		t.Fatalf("namespace %s not deleted within %v: %v", ciliumNamespace, timeout, err)
	}
}
```

This allows us to use a fixed namespace for our tests, but I'm not sure this fits
with the philosophy of kube-test-harness, so feedback is welcome.

The first commit of this PR simplifies `(*Test).removeNamespace` by using the
delete slice trick from https://github.com/golang/go/wiki/SliceTricks and adds a
test for it. This avoid a slice out of bounds access if `DeleteNamespace` is called
for an arbitrary namespace.