### PR TITLE
Fix check for running and ready pods

### DIFF
--- a/pod.go
+++ b/pod.go
@@ -82,7 +82,7 @@ func (test *Test) WaitForPodsReady(namespace string, opts metav1.ListOptions, ex
 			}
 		}
 
-		if runningAndReady == expectedReplicas {
+		if runningAndReady >= expectedReplicas {
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
This commit fixes a scenario where WaitForPodsReady will block waiting
for the pods that are already running and ready, to be ready. However,
the number of ready and running pods are already greater than
`expectedReplicas`.

This is helpful when iterating on a test, rather than deleting the
entire cluster state for every test run.

----------

Please let me know if this is against the spirit of the library. :)