### PR TITLE
Avoid verbose logging from within test helpers

### DIFF
--- a/clusterrole.go
+++ b/clusterrole.go
@@ -12,6 +12,8 @@ import (
 )
 
 func (test *Test) createClusterRole(cr *rbacv1.ClusterRole) error {
+	test.Debugf("creating cluster role %s", cr.Name)
+
 	if _, err := test.harness.kubeClient.RbacV1().ClusterRoles().Create(context.TODO(), cr, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create cluster role %s: %w", cr.Name, err)
 	}
@@ -64,6 +66,8 @@ func (test *Test) CreateClusterRoleFromFile(manifestPath string) *rbacv1.Cluster
 }
 
 func (test *Test) deleteClusterRole(cr *rbacv1.ClusterRole) error {
+	test.Debugf("deleting cluster role %s", cr.Name)
+
 	if err := test.harness.kubeClient.RbacV1().ClusterRoles().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{}); err != nil {
 		return fmt.Errorf("deleting cluster role %s failed: %w", cr.Name, err)
 	}
@@ -86,6 +90,8 @@ func (test *Test) GetClusterRole(name string) (*rbacv1.ClusterRole, error) {
 }
 
 func (test *Test) waitForClusterRoleReady(name string, timeout time.Duration) error {
+	test.Debugf("waiting for cluster role %s to be ready", name)
+
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
 		_, err := test.GetClusterRole(name)
 		if err != nil {

--- a/clusterrolebinding.go
+++ b/clusterrolebinding.go
@@ -12,6 +12,8 @@ import (
 )
 
 func (test *Test) createClusterRoleBinding(crb *rbacv1.ClusterRoleBinding) error {
+	test.Debugf("creating cluster role binding %s", crb.Name)
+
 	if _, err := test.harness.kubeClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), crb, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create cluster role binding %s: %w", crb.Name, err)
 	}
@@ -64,6 +66,8 @@ func (test *Test) CreateClusterRoleBindingFromFile(manifestPath string) *rbacv1.
 }
 
 func (test *Test) deleteClusterRoleBinding(crb *rbacv1.ClusterRoleBinding) error {
+	test.Debugf("deleting cluster role binding %s", crb.Name)
+
 	if err := test.harness.kubeClient.RbacV1().ClusterRoleBindings().Delete(context.TODO(), crb.Name, metav1.DeleteOptions{}); err != nil {
 		return fmt.Errorf("deleting cluster role binding %s failed: %w", crb.Name, err)
 	}
@@ -86,6 +90,8 @@ func (test *Test) GetClusterRoleBinding(name string) (*rbacv1.ClusterRoleBinding
 }
 
 func (test *Test) waitForClusterRoleBindingReady(name string, timeout time.Duration) error {
+	test.Debugf("waiting for cluster role binding %s to be ready", name)
+
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
 		_, err := test.GetClusterRoleBinding(name)
 		if err != nil {

--- a/configmap.go
+++ b/configmap.go
@@ -12,6 +12,8 @@ import (
 )
 
 func (test *Test) createConfigMap(namespace string, cm *v1.ConfigMap) error {
+	test.Debugf("creating configmap %s", cm.Name)
+
 	cm.Namespace = namespace
 	if _, err := test.harness.kubeClient.CoreV1().ConfigMaps(namespace).Create(context.TODO(), cm, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create ConfigMap %s: %w", cm.Name, err)
@@ -65,9 +67,11 @@ func (test *Test) CreateConfigMapFromFile(namespace string, manifestPath string)
 	return d
 }
 
-func (test *Test) deleteConfigMap(ConfigMap *v1.ConfigMap) error {
-	if err := test.harness.kubeClient.CoreV1().ConfigMaps(ConfigMap.Namespace).Delete(context.TODO(), ConfigMap.Name, metav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("deleting ConfigMap %s failed: %w", ConfigMap.Name, err)
+func (test *Test) deleteConfigMap(cm *v1.ConfigMap) error {
+	test.Debugf("deleting configmap %s", cm.Name)
+
+	if err := test.harness.kubeClient.CoreV1().ConfigMaps(cm.Namespace).Delete(context.TODO(), cm.Name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("deleting ConfigMap %s failed: %w", cm.Name, err)
 	}
 	return nil
 }
@@ -95,6 +99,8 @@ func (test *Test) WaitForConfigMapReady(cm *v1.ConfigMap, timeout time.Duration)
 }
 
 func (test *Test) waitForConfigMapReady(ns, name string, timeout time.Duration) error {
+	test.Debugf("waiting for configmap %s to be ready", name)
+
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
 		_, err := test.GetConfigMap(ns, name)
 		if err != nil {

--- a/daemonset.go
+++ b/daemonset.go
@@ -14,7 +14,8 @@ import (
 
 // createDaemonSet creates a daemonset in the given namespace.
 func (test *Test) createDaemonSet(namespace string, d *appsv1.DaemonSet) error {
-	test.Infof("creating daemonset %s", d.Name)
+	test.Debugf("creating daemonset %s", d.Name)
+
 	d.Namespace = namespace
 	_, err := test.harness.kubeClient.AppsV1().DaemonSets(namespace).Create(context.TODO(), d, metav1.CreateOptions{})
 	if err != nil {
@@ -81,8 +82,7 @@ func (test *Test) GetDaemonSet(ns, name string) (*appsv1.DaemonSet, error) {
 
 // waitForDaemonSetReady waits until all replica pods are running and ready.
 func (test *Test) waitForDaemonSetReady(d *appsv1.DaemonSet, timeout time.Duration) error {
-
-	test.Infof("waiting for daemonset %s to be ready", d.Name)
+	test.Debugf("waiting for daemonset %s to be ready", d.Name)
 
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
 		current, err := test.GetDaemonSet(d.Namespace, d.Name)
@@ -106,7 +106,7 @@ func (test *Test) WaitForDaemonSetReady(d *appsv1.DaemonSet, timeout time.Durati
 
 // deleteDaemonSet deletes a daemonset in the given namespace.
 func (test *Test) deleteDaemonSet(d *appsv1.DaemonSet) error {
-	test.Infof("deleting daemonset %s ", d.Name)
+	test.Debugf("deleting daemonset %s ", d.Name)
 
 	d, err := test.GetDaemonSet(d.Namespace, d.Name)
 	if err != nil {
@@ -123,7 +123,7 @@ func (test *Test) DeleteDaemonSet(d *appsv1.DaemonSet) {
 
 // waitForDaemonSetDeleted waits until a deleted daemonset has disappeared from the cluster.
 func (test *Test) waitForDaemonSetDeleted(d *appsv1.DaemonSet, timeout time.Duration) error {
-	test.Infof("waiting for daemonset %s to be deleted", d.Name)
+	test.Debugf("waiting for daemonset %s to be deleted", d.Name)
 
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
 

--- a/deployment.go
+++ b/deployment.go
@@ -14,7 +14,8 @@ import (
 
 // CreateDeployment creates a deployment in the given namespace.
 func (test *Test) createDeployment(namespace string, d *appsv1.Deployment) error {
-	test.Infof("creating deployment %s", d.Name)
+	test.Debugf("creating deployment %s", d.Name)
+
 	d.Namespace = namespace
 	_, err := test.harness.kubeClient.AppsV1().Deployments(namespace).Create(context.TODO(), d, metav1.CreateOptions{})
 	if err != nil {
@@ -81,9 +82,9 @@ func (test *Test) GetDeployment(ns, name string) (*appsv1.Deployment, error) {
 
 // waitForDeploymentReady waits until all replica pods are running and ready.
 func (test *Test) waitForDeploymentReady(d *appsv1.Deployment, timeout time.Duration) error {
-	numReady := int32(0)
+	test.Debugf("waiting for deployment %s to be ready", d.Name)
 
-	test.Infof("waiting for deployment %s to be ready", d.Name)
+	numReady := int32(0)
 
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
 		current, err := test.GetDeployment(d.Namespace, d.Name)
@@ -111,7 +112,7 @@ func (test *Test) WaitForDeploymentReady(d *appsv1.Deployment, timeout time.Dura
 
 // deleteDeployment deletes a deployment in the given namespace.
 func (test *Test) deleteDeployment(d *appsv1.Deployment) error {
-	test.Infof("deleting deployment %s ", d.Name)
+	test.Debugf("deleting deployment %s ", d.Name)
 
 	d, err := test.GetDeployment(d.Namespace, d.Name)
 	if err != nil {
@@ -135,7 +136,7 @@ func (test *Test) DeleteDeployment(d *appsv1.Deployment) {
 
 // waitForDeploymentDeleted waits until a deleted deployment has disappeared from the cluster.
 func (test *Test) waitForDeploymentDeleted(d *appsv1.Deployment, timeout time.Duration) error {
-	test.Infof("waiting for deployment %s to be deleted", d.Name)
+	test.Debugf("waiting for deployment %s to be deleted", d.Name)
 
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
 

--- a/namespace.go
+++ b/namespace.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (test *Test) createNamespace(name string) (*v1.Namespace, error) {
-	test.Infof("creating namespace %s", name)
+	test.Debugf("creating namespace %s", name)
 
 	namespace, err := test.harness.kubeClient.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -24,7 +24,6 @@ func (test *Test) createNamespace(name string) (*v1.Namespace, error) {
 
 // CreateNamespace creates a new namespace.
 func (test *Test) CreateNamespace(name string) {
-
 	_, err := test.createNamespace(name)
 	test.err(err)
 
@@ -39,7 +38,7 @@ func (test *Test) CreateNamespace(name string) {
 }
 
 func (test *Test) deleteNamespace(name string) error {
-	test.Infof("deleting namespace %s", name)
+	test.Debugf("deleting namespace %s", name)
 
 	test.removeNamespace(name)
 

--- a/node.go
+++ b/node.go
@@ -47,9 +47,9 @@ func (test *Test) NodeReady(node *v1.Node) bool {
 
 // waitForDeploymentReady waits until all replica pods are running and ready.
 func (test *Test) waitForNodesReady(expectedNodes int, timeout time.Duration) error {
-	numReady := 0
+	test.Debugf("waiting for %d nodes to be ready", expectedNodes)
 
-	test.Infof("waiting for %d nodes to be ready", expectedNodes)
+	numReady := 0
 
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
 		current, err := test.listNodes(metav1.ListOptions{})

--- a/service.go
+++ b/service.go
@@ -12,6 +12,8 @@ import (
 )
 
 func (test *Test) createService(namespace string, service *v1.Service) error {
+	test.Debugf("creating service %s", service.Name)
+
 	service.Namespace = namespace
 	if _, err := test.harness.kubeClient.CoreV1().Services(namespace).Create(context.TODO(), service, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create service %s: %w", service.Name, err)
@@ -85,7 +87,8 @@ func (test *Test) CreateServiceFromFile(namespace string, manifestPath string) *
 }
 
 func (test *Test) waitForServiceReady(service *v1.Service) error {
-	test.Infof("waiting for service %s to be ready", service.Name)
+	test.Debugf("waiting for service %s to be ready", service.Name)
+
 	err := wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
 		endpoints, err := test.getEndpoints(service.Namespace, service.Name)
 		if err != nil {
@@ -105,6 +108,8 @@ func (test *Test) WaitForServiceReady(service *v1.Service) {
 }
 
 func (test *Test) deleteService(service *v1.Service) error {
+	test.Debugf("deleting service %s", service.Name)
+
 	if err := test.harness.kubeClient.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{}); err != nil {
 		return fmt.Errorf("deleting service %v failed: %w", service.Name, err)
 	}
@@ -118,7 +123,7 @@ func (test *Test) DeleteService(service *v1.Service) {
 }
 
 func (test *Test) waitForServiceDeleted(service *v1.Service) error {
-	test.Infof("waiting for service %s to be deleted", service.Name)
+	test.Debugf("waiting for service %s to be deleted", service.Name)
 
 	err := wait.Poll(5*time.Second, time.Minute, func() (bool, error) {
 		_, err := test.getEndpoints(service.Namespace, service.Name)

--- a/serviceaccount.go
+++ b/serviceaccount.go
@@ -12,6 +12,8 @@ import (
 )
 
 func (test *Test) createServiceAccount(namespace string, serviceAccount *v1.ServiceAccount) error {
+	test.Debugf("creating serviceaccount %s", serviceAccount.Name)
+
 	serviceAccount.Namespace = namespace
 	if _, err := test.harness.kubeClient.CoreV1().ServiceAccounts(namespace).Create(context.TODO(), serviceAccount, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create ServiceAccount %s: %w", serviceAccount.Name, err)
@@ -66,6 +68,8 @@ func (test *Test) CreateServiceAccountFromFile(namespace string, manifestPath st
 }
 
 func (test *Test) deleteServiceAccount(serviceAccount *v1.ServiceAccount) error {
+	test.Debugf("deleting serviceaccount %s ", serviceAccount.Name)
+
 	if err := test.harness.kubeClient.CoreV1().ServiceAccounts(serviceAccount.Namespace).Delete(context.TODO(), serviceAccount.Name, metav1.DeleteOptions{}); err != nil {
 		return fmt.Errorf("deleting ServiceAccount %s failed: %w", serviceAccount.Name, err)
 	}
@@ -84,7 +88,8 @@ func (test *Test) GetServiceAccount(namespace, name string) (*v1.ServiceAccount,
 }
 
 func (test *Test) waitForServiceAccountReady(serviceAccount *v1.ServiceAccount) error {
-	test.Infof("waiting for ServiceAccount %s to be ready", serviceAccount.Name)
+	test.Debugf("waiting for serviceaccount %s to be ready", serviceAccount.Name)
+
 	err := wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
 		_, err := test.GetServiceAccount(serviceAccount.Namespace, serviceAccount.Name)
 		if err != nil {


### PR DESCRIPTION
Convert all `test.Infof` calls in test helper funcs to `test.Debugf`. These
may clutter the test logs and not all all users may want these logs.
Also make the logging consistent by making all helpers log in the same
way.
