### PR TITLE
Fix golint error

### DIFF
--- a/node.go
+++ b/node.go
@@ -76,9 +76,8 @@ func (test *Test) waitForNodesReady(expectedNodes int, exact bool, timeout time.
 
 		if exact {
 			return currentNumReady == expectedNodes, nil
-		} else {
-			return currentNumReady >= expectedNodes, nil
 		}
+		return currentNumReady >= expectedNodes, nil
 	})
 }
 


### PR DESCRIPTION
Fix the following golint error introduced by #46:

```
node.go:79:10: `if` block ends with a `return` statement, so drop this `else` and outdent its block (golint)
```